### PR TITLE
Fix error when running `python setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ except Exception as _:
 setup(
     name="dualpipe",
     version="1.0.0" + rev,
+    packages=["dualpipe"],
 )


### PR DESCRIPTION
Fix following:
```
root@e01-cn-zqb44ql9k3n:~/DualPipe# python setup.py develop
error: Multiple top-level packages discovered in a flat-layout: ['images', 'dualpipe'].
                                                      
To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.
                                                   
If you are trying to create a single distribution with multiple packages
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.
```